### PR TITLE
Make the plugin compatible with the latest Sketch

### DIFF
--- a/src/my-command.js
+++ b/src/my-command.js
@@ -25,9 +25,9 @@ export default function() {
           importer.prepareToImportFromURL_error(NSURL.fileURLWithPath(filepath), null);
         }
 
-        const width = importer.graph().width();
+        const width = importer.graph().element().width();
 
-        const frame = NSMakeRect(currentX, 0, width, importer.graph().height());
+        const frame = NSMakeRect(currentX, 0, width, importer.graph().element().height());
         const root = MSArtboardGroup.alloc().initWithFrame(frame);
         root.name = name;
         importer.graph().makeLayerWithParentLayer_progress(root, null);


### PR DESCRIPTION
I believe this single change is enough to support at least Sketch 98 and 99 Beta. Addresses #18.

----

> I'm also attaching a pre-built `.sketchplugin` for people to grab and test until this PR is landed and the official update is out:
[import-svg-as-artboard.Sketch-98.sketchplugin.zip](https://github.com/mathieudutour/import-svg-as-artboard/files/12840953/import-svg-as-artboard.Sketch-98.sketchplugin.zip)
