### PR TITLE
Support SVGs with a non-zero origin viewBox

### DIFF
--- a/src/my-command.js
+++ b/src/my-command.js
@@ -39,10 +39,13 @@ export default function() {
         importer.graph().makeLayerWithParentLayer_progress(root, null);
         root.ungroupSingleChildDescendentGroups();
         importer.scale_rootGroup(importer.importer().scaleValue(), root);
+        // The container might have shifted from the desired location a bit after scaling
+        root.frame().setX(currentX);
+        root.frame().setY(0);
 
         selectedPage.layers.unshift(root);
 
-        currentX += width + 20;
+        currentX += root.frame().width() + 20;
       })
   );
 }

--- a/src/my-command.js
+++ b/src/my-command.js
@@ -1,5 +1,6 @@
 import path from "path";
 import sketch from "sketch";
+import util from "util";
 import dialog from "@skpm/dialog";
 
 export default function() {
@@ -25,6 +26,11 @@ export default function() {
           importer.prepareToImportFromURL_error(NSURL.fileURLWithPath(filepath), null);
         }
 
+        const viewBox = viewBoxForImporter(importer);
+        if (viewBox.x != 0 || viewBox.y != 0) {
+          recursivelyRebaseSVGElementToZeroOrigin(importer.graph().element(), viewBox);
+        }
+
         const width = importer.graph().element().width();
 
         const frame = NSMakeRect(currentX, 0, width, importer.graph().element().height());
@@ -39,4 +45,33 @@ export default function() {
         currentX += width + 20;
       })
   );
+}
+
+function viewBoxForImporter(importer) {
+  const raw = importer.graph().element().xml()
+    .stringFromAttributeWithName("viewBox")
+    .split(' ').map(Number);
+  return { x: raw[0], y: raw[1], width: raw[2], height: raw[3] };
+}
+
+function recursivelyRebaseSVGElementToZeroOrigin(container, currentViewBox) {
+  const children = util.toArray(container.children().allObjects());
+  children.forEach(el => {
+    if (el.isKindOfClass(SVGGroupElement)) {
+      recursivelyRebaseSVGElementToZeroOrigin(el, currentViewBox);
+    }
+    else if (el.isKindOfClass(SVGCircleShape) || el.isKindOfClass(SVGEllipseShape)) {
+      el.setCx(el.cx() - currentViewBox.x);
+      el.setCy(el.cy() - currentViewBox.y);
+    }
+    else if (el.isKindOfClass(SVGText)) {
+      el.setX(el.x() - currentViewBox.x);
+      el.setY(el.y() - currentViewBox.y);
+    }
+    else if (el.isKindOfClass(SVGPathShape)) {
+      const rebase = NSAffineTransform.transform();
+      rebase.translateXBy_yBy(-currentViewBox.x, -currentViewBox.y);
+      el.path().transformUsingAffineTransform(rebase);
+    }
+  });
 }


### PR DESCRIPTION
As @jazzybeat has rightfully [pointed out](https://github.com/mathieudutour/import-svg-as-artboard/pull/23#issuecomment-1752089026), some SVGs (like [Material Symbols](https://fonts.google.com/icons)) come with a non-zero origin viewBox and the plugin currently does not import their content correctly.

The proposed fix is to manually iterate an SVG tree and translate all coordinates for drawables elements (shapes, texts, paths) to the new zero origin, which makes them appear where expected on the result artboard.

Before/After:
<img width="382" alt="Before/After" src="https://github.com/mathieudutour/import-svg-as-artboard/assets/5719520/a6d678c6-fa31-466d-ab27-e7c6d9320c5a">


----

P.S. I've also fixed artboard canvas layout for cases where imported SVGs were scaled up/down (which results in the corresponding artboards shifting from the desired location to a different one and possibly overlapping others)..